### PR TITLE
Repo name change

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,5 +57,5 @@ jobs:
 
       - name: Run Tests
         run: |
-          docker run -w /var/www/purl.bican.org -v ${{ github.workspace }}:/var/www/purl.bican.org -t purl:latest sudo make all test
+          docker run -w /var/www/purl.brain-bican.org -v ${{ github.workspace }}:/var/www/purl.brain-bican.org -t purl:latest sudo make all test
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This repository is cloned and customized from [OBO Foundry Permanent URLs](https
 
 Please use one of these four options to make changes to the PURLs:
 
-1. [Create a new issue](https://github.com/brain-bican/purl.bican.org/issues/new) describing the change you require.
+1. [Create a new issue](https://github.com/brain-bican/purl.brain-bican.org/issues/new) describing the change you require.
 
-2. [Browse to the configuration file you want to change](https://github.com/brain-bican/purl.bican.org/tree/master/config) and click the "pencil" icon to edit it.
+2. [Browse to the configuration file you want to change](https://github.com/brain-bican/purl.brain-bican.org/tree/master/config) and click the "pencil" icon to edit it.
 
-3. [Add a new configuration file](https://github.com/brain-bican/purl.bican.org/new/master/config).
+3. [Add a new configuration file](https://github.com/brain-bican/purl.brain-bican.org/new/master/config).
 
 4. [Fork this repository](https://help.github.com/articles/fork-a-repo/) and [make a pull request](https://help.github.com/articles/using-pull-requests/).
 
@@ -80,7 +80,7 @@ In the most common case, your PURL should match a unique URL and redirect to a u
      - exact: /pcl-base.owl 
         replacement: https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/master/pcl-base.owl
 
-This entry will match exactly the URL `http://purl.brain-bican.org/ontology/pcl/pcl-base.owl`, and it will redirect to exactly `https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/master/pcl-base.owl`. The matched domain name is fixed `http://purl.bican.org`; the next part is defined by `base_url` `/ontology/pcl/` (namespace should be compatible with the folder `ontology` that the config file resides); the final part is taken from the entry `/pcl-base.owl`. The replacement is expected to be a valid, absolute URL, starting with `http`.
+This entry will match exactly the URL `http://purl.brain-bican.org/ontology/pcl/pcl-base.owl`, and it will redirect to exactly `https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/master/pcl-base.owl`. The matched domain name is fixed `http://purl.brain-bican.org`; the next part is defined by `base_url` `/ontology/pcl/` (namespace should be compatible with the folder `ontology` that the config file resides); the final part is taken from the entry `/pcl-base.owl`. The replacement is expected to be a valid, absolute URL, starting with `http`.
 
 Behind the scenes, the entry is translated into a case-insensitive Apache RedirectMatch directive in `ontology/pcl/.htaccess` by escaping special characters and "anchoring" with initial `^`, the project's base URL, and final `$`:
 
@@ -94,7 +94,7 @@ You can also match and replace just the first part of a URL, leaving the rest un
     - prefix: /releases/
       replacement: https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/v
 
-This entry will match the URL `http://purl.brain-bican.org/ontology/pcl/releases/2022-01-24/pcl.owl` (for example), replace the first part `http://purl.bican.org/ontology/pcl/releases/` with `https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/v`, resulting in `https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/v2022-01-24/pcl.owl`. Effectively, the `pcl.owl` is appended to the replacement.
+This entry will match the URL `http://purl.brain-bican.org/ontology/pcl/releases/2022-01-24/pcl.owl` (for example), replace the first part `http://purl.brain-bican.org/ontology/pcl/releases/` with `https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/v`, resulting in `https://raw.githubusercontent.com/obophenotype/provisional_cell_ontology/v2022-01-24/pcl.owl`. Effectively, the `pcl.owl` is appended to the replacement.
 
 The translation is similar, with the addition of `(.*)` wildcard and a `$1` "backreference" at the ends of the given strings:
 

--- a/config/bican.yml
+++ b/config/bican.yml
@@ -10,4 +10,4 @@ term_browser: custom
 entries:
 
 - exact: /home.html
-  replacement: https://github.com/brain-bican/purl.bican.org/
+  replacement: https://github.com/brain-bican/purl.brain-bican.org/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-## Using purl.bican.org.git in docker
+## Using purl.brain-bican.org.git in docker
 
 #### Installation
 
@@ -25,13 +25,13 @@ secret_key = REPLACE_ME
 #### Clone the repository
 
 ```sh
-git clone https://github.com/brain-bican/purl.bican.org.git
+git clone https://github.com/brain-bican/purl.brain-bican.org.git
 ```
 
 #### Build Purl Image
 
 ```sh
-cd purl.bican.org
+cd purl.brain-bican.org
 docker build -f docker/Dockerfile -t purl:latest .
 docker image list | grep purl 
 ```
@@ -73,7 +73,7 @@ docker image rm purl:latest
 Run tests and safe-update.
 
 ```sh
-cd /var/www/purl.bican.org
+cd /var/www/purl.brain-bican.org
 sudo make all test
 sudo make safe-update
 ```

--- a/provision/PROVISION_AWS_README.md
+++ b/provision/PROVISION_AWS_README.md
@@ -124,7 +124,7 @@ ps -ef                            # Make sure apache and crond are running
 Run tests and safe-update.
 
 ```sh
-cd /var/www/purl.bican.org
+cd /var/www/purl.brain-bican.org
 sudo make all test
 sudo make safe-update
 ```

--- a/provision/vars.yaml
+++ b/provision/vars.yaml
@@ -1,5 +1,5 @@
 owner:      brain-bican
-repo:       purl.bican.org
+repo:       purl.brain-bican.org
 repo_url:   "https://github.com/{{ owner }}/{{ repo }}.git"
 branch:     master
 image:      "{{ repo }}"

--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -4,9 +4,9 @@ Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.network "private_network", ip: "172.16.100.10"
 
-  # Disable the default shared folder, use /var/www/purl.bican.org instead
+  # Disable the default shared folder, use /var/www/purl.brain-bican.org instead
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder "..", "/var/www/purl.bican.org"
+  config.vm.synced_folder "..", "/var/www/purl.brain-bican.org"
 
   # Run Ansible to provision this VM
   config.vm.provision :ansible do |ansible|

--- a/tools/site.yml
+++ b/tools/site.yml
@@ -11,7 +11,7 @@
     mode:      production
     domain:    purl.brain-bican.org
     owner:     brain-bican
-    repo:      purl.bican.org
+    repo:      purl.brain-bican.org
     repo_dir:  "/var/www/{{ repo }}"
     repo_url:  "https://github.com/{{ owner }}/{{ repo }}.git"
     cron_job:  "cd {{ repo_dir }} && make safe-update"

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -1,4 +1,4 @@
 ### Global Failovers!!!
 
 # Redirect anything else to the GitHub page.
-RedirectMatch temp ^.*$ https://github.com/brain-bican/purl.bican.org/
+RedirectMatch temp ^.*$ https://github.com/brain-bican/purl.brain-bican.org/


### PR DESCRIPTION
Repository name changed from purl.bican.org to purl.brain-bican.org