### PR TITLE
CS202210140 taxonomies moved to brain-bican

### DIFF
--- a/config/taxonomy/CCN202210140.yml
+++ b/config/taxonomy/CCN202210140.yml
@@ -4,28 +4,28 @@ idspace: CCN202210140
 base_url: /taxonomy/CCN202210140
 
 products:
-- CS202210140_non-neuronal.json: https://raw.githubusercontent.com/hkir-dev/human-brain-cell-atlas_v1_non-neuronal/main/CS202210140.json
-- CS202210140_neurons.json: https://raw.githubusercontent.com/hkir-dev/human-brain-cell-atlas_v1_neurons/main/CS202210140.json
+- CS202210140_non-neuronal.json: https://raw.githubusercontent.com/brain-bican/human-brain-cell-atlas_v1_non-neuronal/main/CS202210140.json
+- CS202210140_neurons.json: https://raw.githubusercontent.com/brain-bican/human-brain-cell-atlas_v1_neurons/main/CS202210140.json
 - CCN202210140.csv: https://raw.githubusercontent.com/hkir-dev/whole_human_brain_ontology/main/src/dendrograms/nomenclature_table_CS202210140.csv
 
-base_redirect: https://github.com/hkir-dev/human-brain-cell-atlas_v1_non-neuronal
+base_redirect: https://github.com/brain-bican/human-brain-cell-atlas_v1_non-neuronal
 
 entries:
 
 # https://purl.brain-bican.org/taxonomy/CCN202210140/CS202210140_non-neuronal.json
 - exact: /CS202210140_non-neuronal.json
-  replacement: https://raw.githubusercontent.com/hkir-dev/human-brain-cell-atlas_v1_non-neuronal/main/CS202210140.json
+  replacement: https://raw.githubusercontent.com/brain-bican/human-brain-cell-atlas_v1_non-neuronal/main/CS202210140.json
 
 # https://purl.brain-bican.org/taxonomy/CCN202210140/CS202210140_neurons.json
 - exact: /CS202210140_neurons.json
-  replacement: https://raw.githubusercontent.com/hkir-dev/human-brain-cell-atlas_v1_neurons/main/CS202210140.json
+  replacement: https://raw.githubusercontent.com/brain-bican/human-brain-cell-atlas_v1_neurons/main/CS202210140.json
 
 # https://purl.brain-bican.org/taxonomy/CCN202210140/releases/2023-12-20/CS202210140_non-neuronal.json
 - regex: ^/taxonomy/CCN202210140/releases/(.*)/CS202210140_(.*)\.owl$
-  replacement: https://raw.githubusercontent.com/hkir-dev/human-brain-cell-atlas_v1_$2/$1/CS202210140.json
+  replacement: https://raw.githubusercontent.com/brain-bican/human-brain-cell-atlas_v1_$2/$1/CS202210140.json
   tests:
   - from: /CCN202210140/releases/2023-12-20/CS202210140_non-neuronal.json
-    to: https://raw.githubusercontent.com/hkir-dev/human-brain-cell-atlas_v1_non-neuronal/2023-12-20/CS202210140.json
+    to: https://raw.githubusercontent.com/brain-bican/human-brain-cell-atlas_v1_non-neuronal/2023-12-20/CS202210140.json
 
 - exact: /CCN202210140.csv
   replacement: https://raw.githubusercontent.com/hkir-dev/whole_human_brain_ontology/main/src/dendrograms/nomenclature_table_CS202210140.csv
@@ -35,4 +35,4 @@ entries:
 
 ## generic fall-through, serve direct from github by default
 - prefix: /
-  replacement: https://github.com/hkir-dev/human-brain-cell-atlas_v1_neurons/
+  replacement: https://github.com/brain-bican/human-brain-cell-atlas_v1_neurons/


### PR DESCRIPTION
Following projects changes organisation:

- https://github.com/brain-bican/human-brain-cell-atlas_v1_neurons
- https://github.com/brain-bican/human-brain-cell-atlas_v1_non-neuronal

Updated PURLs accordingly